### PR TITLE
make this utility more universally usable

### DIFF
--- a/data-act-csv-export/CONTRIBUTING.md
+++ b/data-act-csv-export/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Welcome!
+
+We're so glad you're thinking about contributing to an 18F open source project! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+
+If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository]( https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
+
+## Public domain
+
+This project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.

--- a/data-act-csv-export/LICENSE.md
+++ b/data-act-csv-export/LICENSE.md
@@ -1,0 +1,31 @@
+As a work of the United States Government, this project is in the
+public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work
+worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the
+work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with
+this deed makes no warranties about the work, and disclaims liability for
+all uses of the work, to the fullest extent permitted by applicable law.
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.

--- a/data-act-csv-export/README.md
+++ b/data-act-csv-export/README.md
@@ -1,7 +1,39 @@
-This is a node script that extracts GitHub issues and comments then exports the data into a csv. 
+# GitHub Issues Export
 
-### Package Dependencies 
+A Node.js script that creates a .csv of GitHub issues and their corresponding comments.
 
-- [octonode](https://github.com/pksunkara/octonode) as a GitHub API wrapper
-- [json2csv](https://www.npmjs.com/package/json2csv) package to convert the GitHub JSON data and export as a csv
-- [async](https://www.npmjs.com/package/async)
+We created this script on behalf of a federal agency partner that was collecting public feedback via GitHub issues. Although the agency used GitHub e-mail notifications to comply with public records laws, they also wanted a way to capture the feedback in a single place.
+
+Before getting started, you'll need a [GitHub account](https://github.com/join "Join GitHub").
+
+## Installation
+
+1. Install [Node.js](https://nodejs.org/en/download/ "download Node.js"). This also installs the npm package manager, which you'll use later to install a few dependencies.
+2. From the command line, clone the project repository from GitHub to your local machine:
+
+        $ git clone git@github.com:18F/data-act-csv-export.git
+
+3. Change to the directory that contains node application:
+
+        $ cd data-act-csv-export/data-act-csv-export
+
+4. Install package dependencies:
+
+        $ npm install
+
+## Usage
+First, you'll need to create a GitHub personal access token. That's because you'll exceed the GitHub API rate limit very quickly if you try running this script as an unauthenticated user.
+
+Make sure you're logged into GitHub, and follow [these directions](https://help.github.com/articles/creating-an-access-token-for-command-line-use/ "Create a GitHub personal access token") to create your token. When asked to _Select scopes_, accept the defaults.
+
+From the command line, run the script (make sure you're in the application folder):
+
+        $ GITHUB_API_KEY=xxxxxxx REPO=githuborg/reponame node index.js
+
+
+* ```GITHUB_API_KEY```: your GitHub personal access token
+* ```REPO```: the GitHub repository you're running the script against
+
+For example, running the following command will grab all issues and their associated comments from the [fedspendingtransparency/fedspendingtransparency.github.io](https://github.com/fedspendingtransparency/fedspendingtransparency.github.io) GitHub repository and write them to a .csv file called _fedspendingtransparency-fedspendingtransparency.github.io-comments-export-[timestamp].csv_
+
+        $ GITHUB_API_KEY=0e8530bsupersecretkey REPO=fedspendingtransparency/fedspendingtransparency.github.io node index.js

--- a/data-act-csv-export/README.md
+++ b/data-act-csv-export/README.md
@@ -26,14 +26,14 @@ First, you'll need to create a GitHub personal access token. That's because you'
 
 Make sure you're logged into GitHub, and follow [these directions](https://help.github.com/articles/creating-an-access-token-for-command-line-use/ "Create a GitHub personal access token") to create your token. When asked to _Select scopes_, accept the defaults.
 
-From the command line, run the script (make sure you're in the application folder):
+From the command line, run the script, passing in the GitHub repo and your personal access token as parameters (make sure you're in the application folder):
 
-        $ GITHUB_API_KEY=xxxxxxx REPO=githuborg/reponame node index.js
+        $ node index.js -r githuborg/reponame -k [GitHub personal access token]
 
 
-* ```GITHUB_API_KEY```: your GitHub personal access token
-* ```REPO```: the GitHub repository you're running the script against
+* ```-r```: the GitHub repository you're running the script against
+* ```-k```: your GitHub personal access token
 
 For example, running the following command will grab all issues and their associated comments from the [fedspendingtransparency/fedspendingtransparency.github.io](https://github.com/fedspendingtransparency/fedspendingtransparency.github.io) GitHub repository and write them to a .csv file called _fedspendingtransparency-fedspendingtransparency.github.io-comments-export-[timestamp].csv_
 
-        $ GITHUB_API_KEY=0e8530bsupersecretkey REPO=fedspendingtransparency/fedspendingtransparency.github.io node index.js
+        $ node index.js -r fedspendingtransparency/fedspendingtransparency.github.io -k 0e8530bsupersecretkey

--- a/data-act-csv-export/index.js
+++ b/data-act-csv-export/index.js
@@ -2,13 +2,34 @@ var async = require('async');
 var fs = require('fs');
 var github =require('octonode');
 var _ = require('underscore');
-
+var program = require('commander');
+var path = require('path');
+var pkg = require( path.join(__dirname, 'package.json') );
 var json2csv = require('json2csv');
 
-var client = github.client(process.env.GITHUB_API_KEY);
-var repo = process.env.REPO;
-var project = repo.split('/')[1]
-var org = repo.split('/')[0]
+program
+    .version(pkg.version)
+    .option('-r, --repo <github repository>',
+        'github repository in format [org-name/repo-name]')
+    .option('-k, --key <github api key>', 'github personal access token')
+    .parse(process.argv);
+
+//check parameters
+if (! program.repo) {
+    console.log('Missing GitHub repo! ' +
+        'Use the -h flag for more info about required parameters.');
+    process.exit();
+}
+if (! program.key) {
+    console.log('Missing GitHub API key! ' +
+        'Use the -h flag for more info about required parameters.');
+    process.exit();
+}
+
+var client = github.client(program.key);
+var repo = program.repo;
+var project = repo.split('/')[1];
+var org = repo.split('/')[0];
 var ghrepo = client.repo(repo);
 
 ghrepo.issues({

--- a/data-act-csv-export/index.js
+++ b/data-act-csv-export/index.js
@@ -6,8 +6,10 @@ var _ = require('underscore');
 var json2csv = require('json2csv');
 
 var client = github.client(process.env.GITHUB_API_KEY);
-
-var ghrepo = client.repo('fedspendingtransparency/fedspendingtransparency.github.io');
+var repo = process.env.REPO;
+var project = repo.split('/')[1]
+var org = repo.split('/')[0]
+var ghrepo = client.repo(repo);
 
 ghrepo.issues({
  	state: 'all',
@@ -39,7 +41,7 @@ ghrepo.issues({
     (function(issueNumber, issueData) {
       commentsReqs.push(function(cb) {
         var currentIssue = client.issue(
-            'fedspendingtransparency/fedspendingtransparency.github.io',
+            repo,
             issueNumber);
         currentIssue.comments(function(err, body, headers) {
           var comments = body,
@@ -96,16 +98,15 @@ ghrepo.issues({
           console.error(err);
           process.exit(1);
         }
-        var fileName = './GitHub-export' + (new Date()).toJSON() + '.csv';
+        var fileName = './' + (org) + '-' + (project) + '-comments-export-' + (new Date()).toJSON() + '.csv';
         fs.writeFileSync(fileName, "");
         fs.appendFile(fileName, data, function (err) {
           if (err) {
             console.error(err);
             process.exit(1);
           }
-          console.log('It\'s saved!');
+          console.log(fileName.concat(' saved!'));
         });
     });
   });
 });
-

--- a/data-act-csv-export/package.json
+++ b/data-act-csv-export/package.json
@@ -10,7 +10,8 @@
   "license": "CC0",
   "dependencies": {
     "json2csv": "^2.2.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "commander": "^2.9.0"
   },
   "devDependencies": {
     "async": "^1.0.0",


### PR DESCRIPTION
Hi @msecret and @elainekamlley! I recently had to run this script to pull some updated numbers for Treasury. This PR contains an update to the README and the application based on that experience:
- README now has more complete install/usage instructions
- index.js now looks for the repo name as a command line parameter (rather than using a hard-coded name)

In addition, added LICENSE.md and CONTRIBUTING.md.

If you all approve of these changes, I'd suggest that the next step is re-naming the repo to something like github-comments-export or something more generic. Thanks for taking a look!
